### PR TITLE
ci(mutants): run on ubuntu-24.04, the glibc cargo-mutants now needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,15 @@ jobs:
   # passes in seconds.
   mutants:
     name: Mutation Testing (changed code)
-    runs-on: ubuntu-22.04
+    # The one job off the repo-wide ubuntu-22.04 pin. cargo-mutants ships
+    # prebuilt binaries linked against glibc 2.39 from v27.1.0 (2026-06-02)
+    # on, and 22.04 carries glibc 2.35 — the install step died with
+    # "cargo-mutants: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39'
+    # not found". That pin exists so shipped binaries stay loadable on older
+    # glibc; this job ships nothing, so it does not apply here. Bumping the
+    # runner rather than pinning an older cargo-mutants keeps the tool on
+    # `latest` like every other install-action call in this file.
+    runs-on: ubuntu-24.04
     # PR-only: --in-diff needs two commits to compare, and on a branch push
     # there is no natural base to diff against.
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## The failure

`Mutation Testing (changed code)` failed on PR #252 at the **Install cargo-mutants** step, before a single mutant was generated:

```
cargo-mutants: /lib/x86_64-linux-gnu/libc.so.6:
version `GLIBC_2.39' not found (required by cargo-mutants)
```

cargo-mutants v27.1.0 (2026-06-02) links its prebuilt binaries against glibc 2.39. `ubuntu-22.04` carries 2.35. `install-action` fetched the binary and verified its checksum successfully — it just could not load it. Since the job pins no version, every PR from here on would have hit this.

It did not show up on the `main` merge because this job is `if: github.event_name == 'pull_request'`.

## The fix

Move this one job to `ubuntu-24.04`.

The repo-wide `ubuntu-22.04` pin exists so shipped binaries stay loadable on older glibc. This job ships nothing — it builds mutants and throws them away — so the pin buys it nothing while costing it the tool.

Bumping the runner rather than pinning an older cargo-mutants keeps the tool on `latest`, consistent with every other `install-action` call in `ci.yml`, and does not re-break as 22.04 falls further behind.

## Verification

This PR is itself the test: the job is PR-only, so opening it is the only way to exercise the change. A green `Mutation Testing (changed code)` here is the proof.