### PR TITLE
fix(validation): UNKNOWN_FUNCTION suggests the nearest registered function

### DIFF
--- a/crates/orion-server/src/engine/handlers.rs
+++ b/crates/orion-server/src/engine/handlers.rs
@@ -61,6 +61,49 @@ pub fn known_functions() -> impl Iterator<Item = &'static str> {
         )
 }
 
+/// The known function nearest to `name`, when one is close enough that a
+/// typo is the likely explanation — the suggestion the `UNKNOWN_FUNCTION`
+/// validation error appends.
+///
+/// Function names are short (4–15 characters), so the fixed distance-3 window
+/// `config/unknown_env.rs` gives env-var overrides would surface suggestions
+/// for inputs that are clearly unrelated ("x" is 3 edits from "map"). The
+/// window here scales with the shorter name — a third of its length, clamped
+/// to 1–3 edits — which covers the realistic typo shapes (a transposed pair,
+/// a doubled letter, a missing suffix) and nothing else.
+pub fn suggest_known_function(name: &str) -> Option<&'static str> {
+    known_functions()
+        .map(|candidate| (edit_distance(name, candidate), candidate))
+        .filter(|(distance, candidate)| {
+            let window = (name.len().min(candidate.len()) / 3).clamp(1, 3);
+            *distance <= window
+        })
+        .min_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)))
+        .map(|(_, candidate)| candidate)
+}
+
+/// Levenshtein distance, two-row form — the same shape as
+/// `config::unknown_env::edit_distance`. The candidate set is ~27 short
+/// names, so this is a few hundred cells per misspelled task name.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    let mut previous: Vec<usize> = (0..=b.len()).collect();
+    let mut current = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let substitution = previous[j] + usize::from(ca != cb);
+            current[j + 1] = substitution.min(previous[j + 1] + 1).min(current[j] + 1);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    previous[b.len()]
+}
+
 /// Function names that require a connector reference.
 pub const CONNECTOR_FUNCTIONS: &[&str] = &[
     "http_call",
@@ -445,6 +488,47 @@ mod tests {
             );
         }
         assert!(!is_known_function("__not_a_function__"));
+    }
+
+    /// The typos the `UNKNOWN_FUNCTION` message exists for: the suggestions
+    /// must be the real, registered names they misspell.
+    #[test]
+    fn suggestion_recovers_common_typos() {
+        for (typo, expected) in [
+            ("mongo_writes", "mongo_write"),
+            ("jwt_verifiy", "jwt_verify"),
+            ("cache_readd", "cache_read"),
+        ] {
+            assert_eq!(
+                suggest_known_function(typo),
+                Some(expected),
+                "'{typo}' should point at '{expected}'"
+            );
+        }
+    }
+
+    /// The window scales with name length, so garbage that is far from every
+    /// registered name gets no suggestion rather than a wrong one —
+    /// `http_request` is a plausible typo but seven edits from `http_call`.
+    #[test]
+    fn suggestion_is_silent_when_nothing_is_close() {
+        assert_eq!(suggest_known_function("http_request"), None);
+        assert_eq!(suggest_known_function("no_such_function_xyz"), None);
+        assert_eq!(suggest_known_function("totally_unrelated"), None);
+        assert_eq!(suggest_known_function("x"), None);
+    }
+
+    /// Suggestions only ever name something the engine can actually run.
+    #[test]
+    fn suggestion_never_names_an_unknown_function() {
+        for typo in ["mongo_writes", "jwt_verifiy", "cache_readd"] {
+            if let Some(candidate) = suggest_known_function(typo) {
+                assert!(
+                    is_known_function(candidate),
+                    "'{candidate}' is suggested for '{typo}' but is not itself registered"
+                );
+            }
+        }
     }
 
     /// F52: the type table and the "needs a connector" list are two views of

--- a/crates/orion-server/src/engine/mod.rs
+++ b/crates/orion-server/src/engine/mod.rs
@@ -67,6 +67,7 @@ pub mod utils;
 pub use handlers::{
     CONNECTOR_FUNCTIONS, HandlerDeps, build_custom_functions, is_known_function, known_functions,
     register_kafka_publisher, required_connector_types, requires_mongo_database,
+    suggest_known_function,
 };
 pub use loader::{CUSTOM_HANDLER_FUNCTIONS, build_engine_workflows, filter_channels};
 pub use observer::MetricsObserver;

--- a/crates/orion-server/src/validation/workflows.rs
+++ b/crates/orion-server/src/validation/workflows.rs
@@ -309,12 +309,15 @@ pub fn validate_workflow_tasks_schema(tasks: &serde_json::Value) -> Vec<FieldErr
             continue;
         }
         if !crate::engine::is_known_function(fn_name) {
+            let suggestion = crate::engine::suggest_known_function(fn_name)
+                .map(|closest| format!(" — did you mean '{closest}'?"))
+                .unwrap_or_default();
             errors.push(FieldError::new(
                 format!("tasks[{i}].function.name"),
                 "UNKNOWN_FUNCTION",
                 format!(
-                    "Unknown function '{fn_name}' — this workflow would be accepted \
-                     and then fail at its first request"
+                    "Unknown function '{fn_name}'{suggestion} — this workflow would be \
+                     accepted and then fail at its first request"
                 ),
             ));
             continue;

--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -157,7 +157,7 @@ a drift test fails the build if `src/` emits one or if this table and the
 | `UNKNOWN_FIELD` | A key the strict parser does not accept — a typo, or a pre-1.0 spelling 1.0 refuses. |
 | `DUPLICATE_FIELD` | The same key appeared twice in one object. |
 | `DUPLICATE_TASK_ID` | Two tasks in one workflow declare the same `id`. |
-| `UNKNOWN_FUNCTION` | A task names a function the engine does not register — the workflow would be accepted and then fail at its first request. |
+| `UNKNOWN_FUNCTION` | A task names a function the engine does not register — the workflow would be accepted and then fail at its first request. When the name is a plausible typo, the message appends the closest registered name (`did you mean …?`). |
 
 ### How `path` is rooted
 


### PR DESCRIPTION
## What & why

Addresses item 1 of #288 only: `UNKNOWN_FUNCTION` names no valid alternative, so an author with a typo gets the vocabulary of 27 names offered nowhere.

The `UNKNOWN_FUNCTION` message now appends the closest registered name when the input is a plausible typo:

```
Unknown function 'mongo_writes' — did you mean 'mongo_write'? — this workflow would be accepted and then fail at its first request
```

`suggest_known_function` walks `known_functions()`, the set the validation gate itself consults, so a suggestion is a name the engine can actually run — including the `RequiresHandler` subtlety (`enrich` is never suggested). The edit-distance window is a third of the shorter name's length, clamped to 1–3, so `http_request` (7 edits from `http_call`) stays silent instead of getting a wrong guess. Message text only: the `field` / `code` shape and the `UNKNOWN_FUNCTION` code are unchanged.

Item 2 (the `/admin/functions` catalogue) involves an API decision between the options in the issue, so I left it for maintainer direction.

## How was it tested?

- Three new unit tests in `engine::handlers::tests`: typo recovery (`mongo_writes`, `jwt_verifiy`, `cache_readd`), silence for far names (`http_request`, `no_such_function_xyz`, `x`), and that every suggestion is itself registered.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (2050 passed), `cargo test --doc` — all clean.

## Checklist

- [x] `cargo fmt && cargo clippy && cargo test` pass cleanly
- [x] New functionality has tests
- [ ] HTTP routes or request/response schemas changed — n/a (error message text only)
- [x] Behaviour changed: docs updated — `docs/src/reference/errors.md` `UNKNOWN_FUNCTION` row notes the suggestion
- [ ] `examples/` changed — n/a
